### PR TITLE
Version 2.2: Ubuntu 14.04, Django 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 vagrant-django-base
 ===================
 
-A Vagrant box based on Ubuntu precise32, configured for Django development
+A Vagrant box based on Ubuntu trusty32, configured for Django development
 according to Torchbox's adopted practices. Things preinstalled beyond the base
-precise32 box include:
+trusty32 box include:
 
-* postgresql 9.1 (with locale fixed to create databases as UTF-8)
+* postgresql 9.3 (with locale fixed to create databases as UTF-8)
 * virtualenv and virtualenvwrapper
-* dependencies for PIL, the Python Imaging Library
+* dependencies for Pillow, a drop-in replacement for the Python Imaging Library PIL
 * a pip download cache pre-seeded with Django and various other common packages
 * git (sometimes required for pip dependencies that aren't in PyPI)
 * Node.js, CoffeeScript and LESS
 
 We use this box in conjunction with https://github.com/torchbox/vagrant-django-template
 as the initial template for our Django projects. vagrant-django-template will
-successfully build from a vanilla precise32 base box, but using vagrant-django-base
+successfully build from a vanilla trusty32 base box, but using vagrant-django-base
 instead will skip some of the time-consuming initial setup.
 
 Build instructions
@@ -25,4 +25,4 @@ To generate the .box file:
 
 To install locally:
 
-    vagrant box add django-base-v2.1 django-base-v2.1.box
+    vagrant box add django-base-v2.2 django-base-v2.2.box

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,11 +3,11 @@
 
 Vagrant::Config.run do |config|
 	# Every Vagrant virtual environment requires a box to build off of.
-	config.vm.box = "precise32"
+	config.vm.box = "ubuntu/trusty32"
 	
 	# The url from where the 'config.vm.box' box will be fetched if it
 	# doesn't already exist on the user's system.
-	config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+	config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
 	
 	# Boot with a GUI so you can see the screen. (Default is headless)
 	# config.vm.boot_mode = :gui

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,8 @@
 
 # to build django-base-v2.box:
 vagrant up
-rm -f django-base-v2.1.box
-vagrant package --output django-base-v2.1.box
+rm -f django-base-v2.2.box
+vagrant package --output django-base-v2.2.box
 
 # to install locally:
-# vagrant box add django-base-v2.1 django-base-v2.1.box
+# vagrant box add django-base-v2.2 django-base-v2.2.box

--- a/data/common_requirements.txt
+++ b/data/common_requirements.txt
@@ -1,9 +1,8 @@
-Django==1.5.4
-South==0.7.6
-psycopg2==2.4.6
-django-devserver==0.5.0
-django-compressor==1.3
-django-debug-toolbar==0.9.4
-Pillow==2.0.0
-gunicorn==0.17.4
-fabric==1.6.1
+Django==1.7.1
+psycopg2==2.5.4
+django-devserver==0.8.0
+django-compressor==1.4
+django-debug-toolbar==1.2.2
+Pillow==2.6.1
+gunicorn==19.1.1
+fabric==1.10.0

--- a/install.sh
+++ b/install.sh
@@ -64,3 +64,10 @@ fi
 if ! command -v lessc; then
     npm install -g less
 fi
+
+# Cleanup
+apt-get clean
+
+echo "Zeroing free space to improve compression."
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 # Script to set up dependencies for Django on Vagrant.
 
-PGSQL_VERSION=9.1
+PGSQL_VERSION=9.3
 
 # Need to fix locale so that Postgres creates databases in UTF-8
 cp -p /vagrant_data/etc-bash.bashrc /etc/bash.bashrc
@@ -17,7 +17,8 @@ export LC_ALL=en_GB.UTF-8
 apt-get update -y
 # Python dev packages
 apt-get install -y build-essential python python-dev python-setuptools python-pip
-# Dependencies for image processing with PIL
+# Dependencies for image processing with Pillow (drop-in replacement for PIL)
+# supporting: jpeg, tiff, png, freetype, littlecms
 apt-get install -y libjpeg-dev libtiff-dev zlib1g-dev libfreetype6-dev liblcms2-dev
 # Git (we'd rather avoid people keeping credentials for git commits in the repo, but sometimes we need it for pip requirements that aren't in PyPI)
 apt-get install -y git


### PR DESCRIPTION
As it says:
- Ubuntu 14.04
- Django 1.7.1
- Postgres 9.3

Also python package version bumps:
- psycopg2 2.4.6 -> 2.5.4
- django-devserver 0.5.0 -> 0.8.0
- django-compressor 1.3 -> 1.4
- django-debug-toolbar 0.9.4 -> 1.2.2
- Pillow 2.0.0 -> 2.6.1
- fabric 1.6.1 -> 1.10.0
- gunicorn 0.17.4 -> 19.1.1
- removal of South

Also added zeroing of empty space on the box before packaging, which saved around 130 MiB.

I haven't specifically checked documentation for known version incompatibilities here, but this built itself and https://github.com/torchbox/vagrant-django-template/pull/10 happily set up for me using this box.

I have assumed a version number bump to 2.2.
